### PR TITLE
Add value store which stores randomized field value   

### DIFF
--- a/easy-random-core/src/main/java/org/jeasy/random/EasyRandomParameters.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/EasyRandomParameters.java
@@ -134,7 +134,7 @@ public class EasyRandomParameters {
         overrideDefaultInitialization = false;
         ignoreRandomizationErrors = false;
         bypassSetters = false;
-        reuseFieldValues = true;
+        reuseFieldValues = false;
         objectPoolSize = DEFAULT_OBJECT_POOL_SIZE;
         randomizationDepth = DEFAULT_RANDOMIZATION_DEPTH;
         dateRange = new Range<>(DEFAULT_DATES_RANGE.getMin().toLocalDate(), DEFAULT_DATES_RANGE.getMax().toLocalDate());

--- a/easy-random-core/src/main/java/org/jeasy/random/EasyRandomParameters.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/EasyRandomParameters.java
@@ -23,19 +23,29 @@
  */
 package org.jeasy.random;
 
-import org.jeasy.random.api.*;
-import org.jeasy.random.randomizers.registry.CustomRandomizerRegistry;
-import org.jeasy.random.randomizers.registry.ExclusionRandomizerRegistry;
+import static java.lang.String.format;
+import static java.time.ZonedDateTime.of;
 
 import java.lang.reflect.Field;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.time.*;
-import java.util.*;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
 import java.util.function.Predicate;
 
-import static java.lang.String.format;
-import static java.time.ZonedDateTime.of;
+import org.jeasy.random.api.ExclusionPolicy;
+import org.jeasy.random.api.ObjectFactory;
+import org.jeasy.random.api.Randomizer;
+import org.jeasy.random.api.RandomizerProvider;
+import org.jeasy.random.api.RandomizerRegistry;
+import org.jeasy.random.randomizers.registry.CustomRandomizerRegistry;
+import org.jeasy.random.randomizers.registry.ExclusionRandomizerRegistry;
 
 /**
  * Parameters of an {@link EasyRandom} instance.
@@ -98,6 +108,7 @@ public class EasyRandomParameters {
     private boolean overrideDefaultInitialization;
     private boolean ignoreRandomizationErrors;
     private boolean bypassSetters;
+    private boolean reuseFieldValues;
     private Range<Integer> collectionSizeRange;
     private Range<Integer> stringLengthRange;
     private Range<LocalDate> dateRange;
@@ -123,6 +134,7 @@ public class EasyRandomParameters {
         overrideDefaultInitialization = false;
         ignoreRandomizationErrors = false;
         bypassSetters = false;
+        reuseFieldValues = true;
         objectPoolSize = DEFAULT_OBJECT_POOL_SIZE;
         randomizationDepth = DEFAULT_RANDOMIZATION_DEPTH;
         dateRange = new Range<>(DEFAULT_DATES_RANGE.getMin().toLocalDate(), DEFAULT_DATES_RANGE.getMax().toLocalDate());
@@ -228,6 +240,14 @@ public class EasyRandomParameters {
 
     public void setBypassSetters(boolean bypassSetters) {
         this.bypassSetters = bypassSetters;
+    }
+
+    public boolean isReuseFieldValues() {
+        return reuseFieldValues;
+    }
+
+    public void setReuseFieldValues(boolean reuseFieldValues) {
+        this.reuseFieldValues = reuseFieldValues;
     }
 
     public ExclusionPolicy getExclusionPolicy() {

--- a/easy-random-core/src/main/java/org/jeasy/random/EasyRandomParameters.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/EasyRandomParameters.java
@@ -626,6 +626,7 @@ public class EasyRandomParameters {
         copy.setOverrideDefaultInitialization(this.isOverrideDefaultInitialization());
         copy.setIgnoreRandomizationErrors(this.isIgnoreRandomizationErrors());
         copy.setBypassSetters(this.isBypassSetters());
+        copy.setReuseFieldValues(this.isReuseFieldValues());
         copy.setCollectionSizeRange(this.getCollectionSizeRange());
         copy.setStringLengthRange(this.getStringLengthRange());
         copy.setDateRange(this.getDateRange());

--- a/easy-random-core/src/main/java/org/jeasy/random/FieldPopulatorWithFieldValueStore.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/FieldPopulatorWithFieldValueStore.java
@@ -1,0 +1,44 @@
+package org.jeasy.random;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+
+import org.jeasy.random.api.RandomizerProvider;
+import org.jeasy.random.util.FieldValueStore;
+import org.jeasy.random.util.ReflectionUtils;
+
+public class FieldPopulatorWithFieldValueStore extends FieldPopulator {
+
+  private final FieldValueStore fieldValueStore;
+
+  FieldPopulatorWithFieldValueStore(final EasyRandom easyRandom,
+                                    final RandomizerProvider randomizerProvider,
+                                    final ArrayPopulator arrayPopulator,
+                                    final CollectionPopulator collectionPopulator,
+                                    final MapPopulator mapPopulator,
+                                    final OptionalPopulator optionalPopulator) {
+    this(easyRandom, randomizerProvider, arrayPopulator, collectionPopulator, mapPopulator, optionalPopulator, new FieldValueStore());
+  }
+
+  FieldPopulatorWithFieldValueStore(final EasyRandom easyRandom,
+                                    final RandomizerProvider randomizerProvider,
+                                    final ArrayPopulator arrayPopulator,
+                                    final CollectionPopulator collectionPopulator,
+                                    final MapPopulator mapPopulator,
+                                    final OptionalPopulator optionalPopulator,
+                                    final FieldValueStore fieldValueStore) {
+    super(easyRandom, randomizerProvider, arrayPopulator, collectionPopulator, mapPopulator, optionalPopulator);
+    this.fieldValueStore = fieldValueStore;
+  }
+
+  @Override
+  void populateField(final Object target, final Field field, final RandomizationContext context) throws IllegalAccessException {
+    Optional<Object> maybeStoredFieldValue = fieldValueStore.get(context.getIndex(), field.getName());
+    if (maybeStoredFieldValue.isPresent()) {
+      ReflectionUtils.setFieldValue(target, field, maybeStoredFieldValue.get());
+      return;
+    }
+    super.populateField(target, field, context);
+    fieldValueStore.put(context.getIndex(), field.getName(), ReflectionUtils.getFieldValue(target, field));
+  }
+}

--- a/easy-random-core/src/main/java/org/jeasy/random/RandomizationContext.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/RandomizationContext.java
@@ -23,12 +23,17 @@
  */
 package org.jeasy.random;
 
-import org.jeasy.random.api.RandomizerContext;
+import static java.util.stream.Collectors.toList;
 
 import java.lang.reflect.Field;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Stack;
 
-import static java.util.stream.Collectors.toList;
+import org.jeasy.random.api.RandomizerContext;
 
 /**
  * Context object for a single call on {@link EasyRandom#nextObject(Class)}.
@@ -48,14 +53,25 @@ class RandomizationContext implements RandomizerContext {
 
     private final Random random;
 
+    private final int index;
+
     private Object rootObject;
 
     RandomizationContext(final Class<?> type, final EasyRandomParameters parameters) {
+        this(0, type, parameters);
+    }
+
+    RandomizationContext(final int index, final Class<?> type, final EasyRandomParameters parameters) {
         this.type = type;
         populatedBeans = new IdentityHashMap<>();
         stack = new Stack<>();
         this.parameters = parameters;
         this.random = new Random(parameters.getSeed());
+        this.index = index;
+    }
+
+    public int getIndex() {
+        return index;
     }
 
     void addPopulatedBean(final Class<?> type, Object object) {

--- a/easy-random-core/src/main/java/org/jeasy/random/randomizers/registry/PositiveValueRandomizerRegistry.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/randomizers/registry/PositiveValueRandomizerRegistry.java
@@ -1,0 +1,101 @@
+package org.jeasy.random.randomizers.registry;
+
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jeasy.random.EasyRandomParameters;
+import org.jeasy.random.annotation.Priority;
+import org.jeasy.random.api.Randomizer;
+import org.jeasy.random.api.RandomizerRegistry;
+import org.jeasy.random.randomizers.range.BigDecimalRangeRandomizer;
+import org.jeasy.random.randomizers.range.BigIntegerRangeRandomizer;
+import org.jeasy.random.randomizers.range.ByteRangeRandomizer;
+import org.jeasy.random.randomizers.range.DoubleRangeRandomizer;
+import org.jeasy.random.randomizers.range.FloatRangeRandomizer;
+import org.jeasy.random.randomizers.range.IntegerRangeRandomizer;
+import org.jeasy.random.randomizers.range.LongRangeRandomizer;
+import org.jeasy.random.randomizers.range.ShortRangeRandomizer;
+
+@Priority(-2)
+public class PositiveValueRandomizerRegistry implements RandomizerRegistry {
+  private final Map<Class<?>, Randomizer<?>> randomizers = new HashMap<>();
+
+  @Override
+  public void init(EasyRandomParameters parameters) {
+    long seed = parameters.getSeed();
+    ByteRangeRandomizer byteRangeRandomizer = new ByteRangeRandomizer(
+        (byte) 1,
+        Byte.MAX_VALUE,
+        seed
+    );
+    randomizers.put(Byte.class, byteRangeRandomizer);
+    randomizers.put(byte.class, byteRangeRandomizer);
+
+    ShortRangeRandomizer shortRangeRandomizer = new ShortRangeRandomizer(
+        (short) 1,
+        Short.MAX_VALUE,
+        seed
+    );
+    randomizers.put(Short.class, shortRangeRandomizer);
+    randomizers.put(short.class, shortRangeRandomizer);
+
+    IntegerRangeRandomizer integerRangeRandomizer = new IntegerRangeRandomizer(
+        1,
+        Integer.MAX_VALUE,
+        seed
+    );
+    randomizers.put(Integer.class, integerRangeRandomizer);
+    randomizers.put(int.class, integerRangeRandomizer);
+
+    LongRangeRandomizer longRangeRandomizer = new LongRangeRandomizer(
+        1L,
+        Long.MAX_VALUE,
+        seed
+    );
+    randomizers.put(Long.class, longRangeRandomizer);
+    randomizers.put(long.class, longRangeRandomizer);
+
+    DoubleRangeRandomizer doubleRangeRandomizer = new DoubleRangeRandomizer(
+        1D,
+        Double.MAX_VALUE,
+        seed
+    );
+    randomizers.put(Double.class, doubleRangeRandomizer);
+    randomizers.put(double.class, doubleRangeRandomizer);
+
+    FloatRangeRandomizer floatRangeRandomizer = new FloatRangeRandomizer(
+        1f,
+        Float.MAX_VALUE,
+        seed
+    );
+    randomizers.put(Float.class, floatRangeRandomizer);
+    randomizers.put(float.class, floatRangeRandomizer);
+
+    BigIntegerRangeRandomizer bigIntegerRangeRandomizer = new BigIntegerRangeRandomizer(
+        1,
+        Integer.MAX_VALUE,
+        seed
+    );
+    randomizers.put(BigInteger.class, bigIntegerRangeRandomizer);
+
+    BigDecimalRangeRandomizer bigDecimalRangeRandomizer = new BigDecimalRangeRandomizer(
+        1D,
+        Double.MAX_VALUE,
+        seed
+    );
+    randomizers.put(BigDecimal.class, bigDecimalRangeRandomizer);
+  }
+
+  @Override
+  public Randomizer<?> getRandomizer(Field field) {
+    return randomizers.get(field.getType());
+  }
+
+  @Override
+  public Randomizer<?> getRandomizer(Class<?> aClass) {
+    return randomizers.get(aClass);
+  }
+}

--- a/easy-random-core/src/main/java/org/jeasy/random/util/FieldValueStore.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/util/FieldValueStore.java
@@ -1,0 +1,31 @@
+package org.jeasy.random.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class FieldValueStore {
+  private final Map<String, Object> valueByKey;
+
+  public FieldValueStore() {
+    this(new HashMap<>());
+  }
+
+  public FieldValueStore(Map<String, Object> valueByKey) {
+    this.valueByKey = valueByKey;
+  }
+
+  public void put(int index, String fieldName, Object value) {
+    String key = buildKey(index, fieldName);
+    valueByKey.put(key, value);
+  }
+
+  public <T> Optional<T> get(int index, String fieldName) {
+    String key = buildKey(index, fieldName);
+    return (Optional<T>) Optional.ofNullable(valueByKey.get(key));
+  }
+
+  private static String buildKey(int index, String fieldName) {
+    return String.format("%d-%s", index, fieldName);
+  }
+}

--- a/easy-random-core/src/test/java/org/jeasy/random/EasyRandomTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/EasyRandomTest.java
@@ -484,10 +484,13 @@ class EasyRandomTest {
 
     @Test
     void generatedBeansShouldBeEqualForSameIndex() {
-        Person person1 = easyRandom.nextObject(Person.class);
+        EasyRandomParameters parameters = new EasyRandomParameters();
+        parameters.setReuseFieldValues(true);
+        EasyRandom easyRandomWithValueStore = new EasyRandom(parameters);
+        Person person1 = easyRandomWithValueStore.nextObject(Person.class);
         validatePerson(person1);
 
-        assertThat(easyRandom.nextOrGetObject(0, Person.class)).isEqualTo(person1);
+        assertThat(easyRandomWithValueStore.nextOrGetObject(0, Person.class)).isEqualTo(person1);
     }
 
     private void validatePerson(final Person person) {

--- a/easy-random-core/src/test/java/org/jeasy/random/EasyRandomTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/EasyRandomTest.java
@@ -74,10 +74,14 @@ class EasyRandomTest {
     private Randomizer<String> randomizer;
 
     private EasyRandom easyRandom;
+    private EasyRandom easyRandomWithValueStore;
 
     @BeforeEach
     void setUp() {
         easyRandom = new EasyRandom();
+        EasyRandomParameters parameters = new EasyRandomParameters();
+        parameters.setReuseFieldValues(true);
+        easyRandomWithValueStore= new EasyRandom(parameters);
     }
 
     @Test
@@ -484,9 +488,6 @@ class EasyRandomTest {
 
     @Test
     void generatedBeansShouldBeEqualForSameIndex() {
-        EasyRandomParameters parameters = new EasyRandomParameters();
-        parameters.setReuseFieldValues(true);
-        EasyRandom easyRandomWithValueStore = new EasyRandom(parameters);
         Person person1 = easyRandomWithValueStore.nextObject(Person.class);
         validatePerson(person1);
 

--- a/easy-random-core/src/test/java/org/jeasy/random/EasyRandomTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/EasyRandomTest.java
@@ -23,8 +23,40 @@
  */
 package org.jeasy.random;
 
+import static java.sql.Timestamp.valueOf;
+import static java.time.LocalDateTime.of;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.jeasy.random.FieldPredicates.hasModifiers;
+import static org.jeasy.random.FieldPredicates.inClass;
+import static org.jeasy.random.FieldPredicates.named;
+import static org.jeasy.random.FieldPredicates.ofType;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Modifier;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Stream;
+
 import org.jeasy.random.api.Randomizer;
-import org.jeasy.random.beans.*;
+import org.jeasy.random.beans.AbstractBean;
+import org.jeasy.random.beans.Address;
+import org.jeasy.random.beans.BoundedBaseClass;
+import org.jeasy.random.beans.Gender;
+import org.jeasy.random.beans.GenericBaseClass;
+import org.jeasy.random.beans.Human;
+import org.jeasy.random.beans.ImmutableBean;
+import org.jeasy.random.beans.Node;
+import org.jeasy.random.beans.Person;
+import org.jeasy.random.beans.Salary;
+import org.jeasy.random.beans.Street;
+import org.jeasy.random.beans.TestBean;
+import org.jeasy.random.beans.TestData;
+import org.jeasy.random.beans.TestEnum;
 import org.jeasy.random.util.ReflectionUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -32,18 +64,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.lang.reflect.Modifier;
-import java.util.*;
-import java.util.stream.Stream;
-
-import static java.sql.Timestamp.valueOf;
-import static java.time.LocalDateTime.of;
-import static java.util.Arrays.asList;
-import static org.assertj.core.api.Assertions.*;
-import static org.assertj.core.api.BDDAssertions.then;
-import static org.jeasy.random.FieldPredicates.*;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class EasyRandomTest {
@@ -460,6 +480,14 @@ class EasyRandomTest {
 
         // then
         assertThat(concrete.getX()).isInstanceOf(String.class);
+    }
+
+    @Test
+    void generatedBeansShouldBeEqualForSameIndex() {
+        Person person1 = easyRandom.nextObject(Person.class);
+        validatePerson(person1);
+
+        assertThat(easyRandom.nextOrGetObject(0, Person.class)).isEqualTo(person1);
     }
 
     private void validatePerson(final Person person) {

--- a/easy-random-core/src/test/java/org/jeasy/random/FieldPopulatorWithFieldValueStoreTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/FieldPopulatorWithFieldValueStoreTest.java
@@ -1,0 +1,88 @@
+package org.jeasy.random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Field;
+
+import org.jeasy.random.api.ContextAwareRandomizer;
+import org.jeasy.random.api.Randomizer;
+import org.jeasy.random.beans.Human;
+import org.jeasy.random.util.FieldValueStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class FieldPopulatorWithFieldValueStoreTest {
+
+  private static final String NAME = "foo1";
+  private static final long ID = 546546L;
+
+  @Mock
+  private EasyRandom easyRandom;
+  @Mock
+  private RegistriesRandomizerProvider randomizerProvider;
+  @Mock
+  private Randomizer randomizer;
+  @Mock
+  private ContextAwareRandomizer contextAwareRandomizer;
+  @Mock
+  private ArrayPopulator arrayPopulator;
+  @Mock
+  private CollectionPopulator collectionPopulator;
+  @Mock
+  private MapPopulator mapPopulator;
+  @Mock
+  private OptionalPopulator optionalPopulator;
+
+  private FieldPopulatorWithFieldValueStore fieldPopulator;
+  private FieldValueStore fieldValueStore;
+
+  @BeforeEach
+  void setUp() {
+    fieldValueStore = new FieldValueStore();
+    fieldPopulator = new FieldPopulatorWithFieldValueStore(easyRandom, randomizerProvider, arrayPopulator, collectionPopulator, mapPopulator, optionalPopulator, fieldValueStore);
+  }
+
+  @Test
+  void whenFieldValuePresentInValueStoreForTheField_thenTheFieldShouldBePopulatedWithTheStoredValue() throws Exception {
+    // Given
+    Field name = Human.class.getDeclaredField("name");
+    Human human = new Human();
+    RandomizationContext context = new RandomizationContext(1, Human.class, new EasyRandomParameters());
+    fieldValueStore.put(1, name.getName(), NAME);
+
+    // When
+    fieldPopulator.populateField(human, name, context);
+
+    // Then
+    assertThat(human.getName()).isEqualTo(NAME);
+    verifyNoInteractions(randomizerProvider);
+    verifyNoInteractions(randomizer);
+    verifyNoInteractions(contextAwareRandomizer);
+    verifyNoInteractions(arrayPopulator);
+    verifyNoInteractions(collectionPopulator);
+    verifyNoInteractions(mapPopulator);
+    verifyNoInteractions(optionalPopulator);
+  }
+
+  @Test
+  void whenFieldValueNotPresentInValueStoreForTheField_thenTheFieldShouldBePopulatedWithTheRandomValue() throws Exception {
+    // Given
+    Field id = Human.class.getDeclaredField("id");
+    Human human = new Human();
+    RandomizationContext context = new RandomizationContext(1, Human.class, new EasyRandomParameters());
+    when(randomizerProvider.getRandomizerByField(id, context)).thenReturn(randomizer);
+    when(randomizer.getRandomValue()).thenReturn(ID);
+
+    // When
+    fieldPopulator.populateField(human, id, context);
+
+    // Then
+    assertThat(human.getId()).isEqualTo(ID);
+    assertThat(fieldValueStore.get(1, id.getName())).hasValue(ID);
+  }
+}


### PR DESCRIPTION
For HubSpot internal needs (for testing), we like to reuse the field values for each index. 

For example, for classes
```java
class Example1 {
 int id;
 String name; 
}
class Example2 {
 int id;
 String name; 
 String something;
}
```

Without field value store, `easyRandom.nextObject` would yield different values for `id`, `name` field for `Example1`  and `Example2` instances. With field value store (this is set in `EasyRandomParameters`), `id` and `name` fields in `Example1` and `Example2` instances  will have same value. 

To handle achieve this extended `FieldPopulator` with `FieldValueStore` . This new class called `FieldPopulatorWithValueStore` is only used for when `reuseFieldValue` is true in `EasyRandomParameters`.
