### PR TITLE
Migrate from JavaFaker to DataFaker

### DIFF
--- a/easy-random-core/src/test/java/org/jeasy/random/EasyRandomTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/EasyRandomTest.java
@@ -61,6 +61,8 @@ import org.jeasy.random.util.ReflectionUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -251,6 +253,10 @@ class EasyRandomTest {
     }
 
     @Test
+    @DisabledForJreRange(
+            disabledReason = "Fails on jdk 17+, see https://github.com/j-easy/easy-random/issues/494",
+            min = JRE.JAVA_16
+    )
     void fieldsOfTypeClassShouldBeSkipped() {
         try {
             TestBean testBean = easyRandom.nextObject(TestBean.class);

--- a/easy-random-core/src/test/java/org/jeasy/random/randomizers/misc/LocaleRandomizerTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/randomizers/misc/LocaleRandomizerTest.java
@@ -23,14 +23,13 @@
  */
 package org.jeasy.random.randomizers.misc;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.jeasy.random.randomizers.AbstractRandomizerTest;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.Locale;
 
-import org.junit.jupiter.api.Test;
-
-import org.jeasy.random.randomizers.AbstractRandomizerTest;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class LocaleRandomizerTest extends AbstractRandomizerTest<Locale> {
 
@@ -42,7 +41,9 @@ class LocaleRandomizerTest extends AbstractRandomizerTest<Locale> {
     @Test
     void shouldGenerateTheSameValueForTheSameSeed() {
         BigDecimal javaVersion = new BigDecimal(System.getProperty("java.specification.version"));
-        if (javaVersion.compareTo(new BigDecimal("14")) >= 0) {
+        if (javaVersion.compareTo(new BigDecimal("17")) >= 0) {
+            assertThat(new LocaleRandomizer(SEED).getRandomValue()).isEqualTo(new Locale("mni", ""));
+        } else if (javaVersion.compareTo(new BigDecimal("14")) >= 0) {
             assertThat(new LocaleRandomizer(SEED).getRandomValue()).isEqualTo(new Locale("rn", "BI"));
         } else if (javaVersion.compareTo(new BigDecimal("13")) >= 0) {
             assertThat(new LocaleRandomizer(SEED).getRandomValue()).isEqualTo(new Locale("zh", "CN"));

--- a/easy-random-randomizers/pom.xml
+++ b/easy-random-randomizers/pom.xml
@@ -54,8 +54,8 @@
             <artifactId>easy-random-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.javafaker</groupId>
-            <artifactId>javafaker</artifactId>
+            <groupId>net.datafaker</groupId>
+            <artifactId>datafaker</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/easy-random-randomizers/src/main/java/org/jeasy/random/randomizers/FakerBasedRandomizer.java
+++ b/easy-random-randomizers/src/main/java/org/jeasy/random/randomizers/FakerBasedRandomizer.java
@@ -23,13 +23,13 @@
  */
 package org.jeasy.random.randomizers;
 
-import com.github.javafaker.Faker;
+import net.datafaker.Faker;
 import org.jeasy.random.api.Randomizer;
 
 import java.util.Locale;
 
 /**
- * Abstract {@link Randomizer} based on <a href="https://github.com/DiUS/java-faker">Faker</a>.
+ * Abstract {@link Randomizer} based on <a href="https://github.com/datafaker-net/datafaker">Data Faker</a>.
  *
  * @param <T> the element type
  * @author Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)

--- a/easy-random-randomizers/src/test/java/org/jeasy/random/randomizers/RandomizersTest.java
+++ b/easy-random-randomizers/src/test/java/org/jeasy/random/randomizers/RandomizersTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *   Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *   Copyright (c) 2023, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal
@@ -23,14 +23,11 @@
  */
 package org.jeasy.random.randomizers;
 
-import static org.assertj.core.api.BDDAssertions.then;
-
-import java.text.DecimalFormatSymbols;
-
+import org.jeasy.random.api.Randomizer;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import org.jeasy.random.api.Randomizer;
+import static org.assertj.core.api.BDDAssertions.then;
 
 class RandomizersTest extends AbstractRandomizerTest<FakerBasedRandomizer<?>>{
 
@@ -75,25 +72,25 @@ class RandomizersTest extends AbstractRandomizerTest<FakerBasedRandomizer<?>>{
                 { new CityRandomizer(SEED), "Breannaberg" },
                 { new CompanyRandomizer(SEED), "Hegmann, Hansen and Mills" },
                 { new CountryRandomizer(SEED), "Peru" },
-                { new CreditCardNumberRandomizer(SEED), "1211-1221-1234-2201" },
-                { new EmailRandomizer(SEED), "jacob.hansen@hotmail.com" }, 
+                { new CreditCardNumberRandomizer(SEED), "6762-0695-7475-3962" },
+                { new EmailRandomizer(SEED), "jacob.hansen@hotmail.com" },
                 { new FirstNameRandomizer(SEED), "Jacob" },
                 { new FullNameRandomizer(SEED), "Breanna Mills" },
                 { new Ipv4AddressRandomizer(SEED), "16.188.76.229" },
                 { new Ipv6AddressRandomizer(SEED), "b3f4:4994:c9e8:b21a:c493:e923:f711:1115" },
-                { new IsbnRandomizer(SEED), "9781797845005" },
+                { new IsbnRandomizer(SEED), "9790865070867" },
                 { new LastNameRandomizer(SEED), "Durgan" },
-                { new LatitudeRandomizer(SEED), "40" + new DecimalFormatSymbols().getDecimalSeparator() + "171357" },
-                { new LongitudeRandomizer(SEED), "80" + new DecimalFormatSymbols().getDecimalSeparator() + "342713" },
+                { new LatitudeRandomizer(SEED), "40.17135654" },
+                { new LongitudeRandomizer(SEED), "80.34271308" },
                 { new MacAddressRandomizer(SEED), "b3:f4:49:94:c9:e8" },
                 { new ParagraphRandomizer(SEED), "Totam assumenda eius autem similique. Aut voluptatem enim praesentium. Suscipit cupiditate doloribus debitis dolor. Cumque sapiente occaecati. Quos maiores quae." },
-                { new PhoneNumberRandomizer(SEED), "1-069-574-7539" },
+                { new PhoneNumberRandomizer(SEED), "(352) 773-9574 x7539" },
                 { new RegularExpressionRandomizer("\\d+[A-Z]{5}", SEED), "8UYSMT" },
                 { new SentenceRandomizer(SEED), "Dolor totam assumenda eius autem." },
                 { new StateRandomizer(SEED), "North Carolina" },
                 { new StreetRandomizer(SEED), "Hegmann Locks" },
                 { new WordRandomizer(SEED), "repellat" },
-                { new ZipCodeRandomizer(SEED), "06957-4753" }
+                { new ZipCodeRandomizer(SEED), "20695" }
         };
     }
 
@@ -108,27 +105,27 @@ class RandomizersTest extends AbstractRandomizerTest<FakerBasedRandomizer<?>>{
 
     static Object[][] generateSeededRandomizersWithLocaleAndTheirExpectedValues() {
         return new Object[][] {
-                { new CityRandomizer(SEED, LOCALE), "Versailles" },
+                { new CityRandomizer(SEED, LOCALE), "Neuilly-sur-Seine" },
                 { new CompanyRandomizer(SEED, LOCALE), "Masson et Lambert" },
                 { new CountryRandomizer(SEED, LOCALE), "Peru" },
-                { new CreditCardNumberRandomizer(SEED, LOCALE), "1211-1221-1234-2201" },
-                { new EmailRandomizer(SEED, LOCALE), "alice.masson@hotmail.fr" }, 
+                { new CreditCardNumberRandomizer(SEED, LOCALE), "6762-0695-7475-3962" },
+                { new EmailRandomizer(SEED, LOCALE), "alice.masson@hotmail.fr" },
                 { new FirstNameRandomizer(SEED, LOCALE), "Alice" },
                 { new FullNameRandomizer(SEED, LOCALE), "Masson Emilie" },
                 { new Ipv4AddressRandomizer(SEED, LOCALE), "16.188.76.229" },
                 { new Ipv6AddressRandomizer(SEED, LOCALE), "b3f4:4994:c9e8:b21a:c493:e923:f711:1115" },
-                { new IsbnRandomizer(SEED, LOCALE), "9781797845005" },
+                { new IsbnRandomizer(SEED, LOCALE), "9790865070867" },
                 { new LastNameRandomizer(SEED, LOCALE), "Faure" },
-                { new LatitudeRandomizer(SEED, LOCALE), "40" + new DecimalFormatSymbols().getDecimalSeparator() + "171357" }, // should really be "40.171357", seems like a bug in java-faker
-                { new LongitudeRandomizer(SEED, LOCALE), "80" + new DecimalFormatSymbols().getDecimalSeparator() + "342713" }, // should really be "80.342713", seems like a bug in java-faker
+                { new LatitudeRandomizer(SEED, LOCALE), "40,17135654" },
+                { new LongitudeRandomizer(SEED, LOCALE), "80,34271308" },
                 { new MacAddressRandomizer(SEED, LOCALE), "b3:f4:49:94:c9:e8" },
                 { new ParagraphRandomizer(SEED, LOCALE), "Totam assumenda eius autem similique. Aut voluptatem enim praesentium. Suscipit cupiditate doloribus debitis dolor. Cumque sapiente occaecati. Quos maiores quae." },
                 { new PhoneNumberRandomizer(SEED, LOCALE), "03 06 95 74 75" },
                 { new SentenceRandomizer(SEED, LOCALE), "Dolor totam assumenda eius autem." },
                 { new StateRandomizer(SEED, LOCALE), "Lorraine" },
-                { new StreetRandomizer(SEED, LOCALE), "Rue de Presbourg" },
+                { new StreetRandomizer(SEED, LOCALE), "Passage des Francs-Bourgeois" },
                 { new WordRandomizer(SEED, LOCALE), "repellat" },
-                { new ZipCodeRandomizer(SEED, LOCALE), "06957" }
+                { new ZipCodeRandomizer(SEED, LOCALE), "20695" }
         };
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
         <junit.version>5.7.0</junit.version>
+        <datafaker.version>2.0.1</datafaker.version>
         <faker.version>1.0.2</faker.version>
         <assertj.version>3.18.0</assertj.version>
         <validation-api.version>2.0.1.Final</validation-api.version>
@@ -149,9 +150,9 @@
                 <version>${javax.el.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.javafaker</groupId>
-                <artifactId>javafaker</artifactId>
-                <version>${faker.version}</version>
+                <groupId>net.datafaker</groupId>
+                <artifactId>datafaker</artifactId>
+                <version>${datafaker.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Updates the dependency on the out-of-data JavaFaker to DataFaker. 
My hope was that I'd just be able to re-sync the fork, or at worst cherry-pick the appropriate commit from upstream, but I don't think either of those are feasible, unfortunately. The 6.0.0 release of easy-random re-organized the module structure (specifically it moved everything from `-randomizers` into the base module), which makes porting dependents to the new release somewhat painful. Given that easy-random itself is a little out-of-date, I probably would lean towards migrating this to something internal rather than migrating to the new release of easy-random.

Change from JavaFaker to DataFaker required picking up java 17 as well, which in turn required a handful of test changes. Those test changes are mostly just copied out of the easy-random repo as appropriate